### PR TITLE
Set up basic static quiz app skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+/dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# ThickerSkinApp
+# ThickerSkin Quiz
+
+Minimal setup for a static quiz application using Tailwind CSS.
+
+## Development
+
+Install dependencies and build Tailwind:
+
+```bash
+npm install
+npx tailwindcss -i ./src/css/styles.css -o ./public/styles.css --watch
+```
+
+Open `public/index.html` in your browser to run locally.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "thickerskinapp",
+  "version": "1.0.0",
+  "description": "Static quiz site",
+  "scripts": {
+    "test": "echo 'No tests'"
+  },
+  "type": "module"
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ThickerSkin Quiz</title>
+  <!-- Tailwind via CDN for quick setup -->
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="manifest" href="/manifest.json" />
+</head>
+<body class="bg-gray-100 text-gray-900 font-sans">
+  <div id="app" class="p-4 max-w-xl mx-auto">
+    <h1 class="text-2xl font-bold mb-4">ThickerSkin Quiz</h1>
+    <div id="quiz-container"></div>
+  </div>
+  <script type="module" src="/src/js/quiz.js"></script>
+  <script type="module" src="/src/js/analytics.js"></script>
+</body>
+</html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "ThickerSkin Quiz",
+  "short_name": "Quiz",
+  "start_url": "/index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#111827",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "64x64 32x32 24x24 16x16",
+      "type": "image/x-icon"
+    }
+  ]
+}

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Custom styles */
+body {
+  font-family: 'Space Grotesk', sans-serif;
+}

--- a/src/data/questions.json
+++ b/src/data/questions.json
@@ -1,0 +1,10 @@
+[
+  {
+    "question": "How often do you seek new challenges?",
+    "options": ["Rarely", "Sometimes", "Often", "Always"]
+  },
+  {
+    "question": "Do you prefer working in a team?",
+    "options": ["Never", "Occasionally", "Usually", "Always"]
+  }
+]

--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -1,0 +1,4 @@
+export function trackEvent(name, data = {}) {
+  console.log('Track event', name, data);
+  // TODO: integrate GTM, GA4, Klaviyo here
+}

--- a/src/js/quiz.js
+++ b/src/js/quiz.js
@@ -1,0 +1,29 @@
+import questions from '../data/questions.json' assert { type: 'json' };
+
+const container = document.getElementById('quiz-container');
+let current = 0;
+let answers = [];
+
+function renderQuestion() {
+  if (current >= questions.length) {
+    container.innerHTML = `<p class="font-bold">Thanks for completing the quiz!</p>`;
+    return;
+  }
+  const q = questions[current];
+  container.innerHTML = `
+    <div class="mb-4">
+      <p class="mb-2">${q.question}</p>
+      ${q.options.map((o,i)=>`<button class='answer border px-4 py-2 m-1' data-index="${i}">${o}</button>`).join('')}
+    </div>
+  `;
+  container.querySelectorAll('.answer').forEach(btn => {
+    btn.addEventListener('click', () => {
+      answers[current] = btn.dataset.index;
+      current++;
+      renderQuestion();
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', renderQuestion);
+export { answers };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './public/**/*.html',
+    './src/js/**/*.js'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "cleanUrls": true,
+  "rewrites": [
+    { "source": "/", "destination": "/public/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add public HTML entry point and manifest
- wire up simple quiz logic and analytics stub
- include sample questions and Tailwind config
- document build steps in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68844e495bac832d99a2ec4de21e85af